### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1069,7 +1069,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $.find( element ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/UGURAKSAHIN/MyPortfolio/security/code-scanning/2](https://github.com/UGURAKSAHIN/MyPortfolio/security/code-scanning/2)

To fix the problem, we need to ensure that any user-controlled input used in jQuery selectors is properly sanitized to prevent XSS attacks. Specifically, we should use jQuery's `find` method instead of directly using the `$` function to ensure that the input is always treated as a CSS selector and not as HTML.

1. Replace the use of `$(element)` with `$.find(element)` in the `validationTargetFor` function.
2. Ensure that any other instances where user-controlled input is used in jQuery selectors are similarly sanitized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
